### PR TITLE
Clang/OSX cleanups

### DIFF
--- a/cli/x52_cli.c
+++ b/cli/x52_cli.c
@@ -333,7 +333,6 @@ static int do_help(const struct command_handler *cmd)
 int main(int argc, char **argv)
 {
     libx52_device *x52;
-    int command;
     struct string_map result;
     const struct command_handler *cmd;
     int i;

--- a/cli/x52_cli.c
+++ b/cli/x52_cli.c
@@ -326,6 +326,8 @@ static int do_help(const struct command_handler *cmd)
 
         printf("\nWARNING: raw command may damage your device\n\n");
     }
+
+    return 0;
 }
 
 int main(int argc, char **argv)

--- a/libx52/x52_control.c
+++ b/libx52/x52_control.c
@@ -22,7 +22,7 @@
 int libx52_vendor_command(libx52_device *x52, uint16_t index, uint16_t value)
 {
     int j;
-    int rc = LIBUSB_ERROR_OTHER;
+    int rc = 0;
 
     /* Allow retry in case of failure */
     for (j = 0; j < 3; j++) {
@@ -168,7 +168,7 @@ int libx52_update(libx52_device *x52)
     unsigned int i;
     uint32_t update_mask;
     uint16_t value;
-    int rc = LIBUSB_ERROR_OTHER;
+    int rc = 0;
 
     /* Save the update mask */
     update_mask = x52->update_mask;

--- a/libx52/x52_control.c
+++ b/libx52/x52_control.c
@@ -22,7 +22,7 @@
 int libx52_vendor_command(libx52_device *x52, uint16_t index, uint16_t value)
 {
     int j;
-    int rc;
+    int rc = LIBUSB_ERROR_OTHER;
 
     /* Allow retry in case of failure */
     for (j = 0; j < 3; j++) {
@@ -110,7 +110,7 @@ static int libx52_write_date(libx52_device *x52)
 
 static int libx52_write_time(libx52_device *x52, libx52_clock_id clock)
 {
-    uint16_t value;
+    uint16_t value = 0;
     uint16_t index;
     int offset;
     int negative;
@@ -168,7 +168,7 @@ int libx52_update(libx52_device *x52)
     unsigned int i;
     uint32_t update_mask;
     uint16_t value;
-    int rc;
+    int rc = LIBUSB_ERROR_OTHER;
 
     /* Save the update mask */
     update_mask = x52->update_mask;

--- a/libx52/x52_core.c
+++ b/libx52/x52_core.c
@@ -55,7 +55,11 @@ libx52_device* libx52_init(void)
 
     rc = libusb_init(&(x52_dev->ctx));
     if (rc) {
+#if defined(__linux__)
         errno = ELIBACC;
+#else
+        errno = ENOENT;
+#endif
         goto err_recovery;
     }
     libusb_set_debug(x52_dev->ctx, 3);

--- a/libx52/x52_date_time.c
+++ b/libx52/x52_date_time.c
@@ -39,7 +39,7 @@ int libx52_set_clock(libx52_device *x52, time_t time, int local)
         /* timezone from time.h presents the offset in seconds west of GMT.
          * Negate and divide by 60 to get the offset in minutes east of GMT.
          */
-        local_tz = -timezone / 60;
+        local_tz = (int)(-timezone / 60);
     } else {
         timeval = *gmtime(&time);
         /* No offset from GMT */

--- a/test/x52_test_led.c
+++ b/test/x52_test_led.c
@@ -75,4 +75,6 @@ int test_blink_n_shift(void)
 
     TEST_BLINK_OR_SHIFT(blink);
     TEST_BLINK_OR_SHIFT(shift);
+
+    return 0;
 }

--- a/test/x52_test_mfd.c
+++ b/test/x52_test_mfd.c
@@ -78,8 +78,6 @@ int test_mfd_text(void)
 int test_mfd_display(void)
 {
     int i;
-    int j;
-    int rc;
     char str[16];
 
     print_banner("MFD display");


### PR DESCRIPTION
This pull request contains 4 fixes: 2 warning cleanups, 1 clang error (control may read end of non-void function), and 1 commit to guard ELIBACC within __linux__ since this error code is Linux specific. With these changes, x52pro-linux ALMOST compiles cleanly on macOS Sierra.

Note, this project will emit several warnings when compiled with -Wenum-conversion. I have not addressed these warnings.