### PR TITLE
ci: Add permissions blocks to action definitions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build/Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,9 @@
 name: "CodeQL"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   pull_request:
     # The branches below must be a subset of the branches above

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -1,5 +1,8 @@
 name: Kernel Module
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ '*' ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Create Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
CodeQL identified a medium severity security issue with the action definitions not including a permissions block as required by modern security practices. This change ensures that the majority of the actions force the token to be read-only and not accidentally write content back into the repository.